### PR TITLE
Fix logic error excluding nvd linked CVEs

### DIFF
--- a/content.js
+++ b/content.js
@@ -24,8 +24,14 @@ function highlightCVEs(node) {
     if (node.nodeType === Node.TEXT_NODE) {
       const parent = node.parentNode;
 
-      // Skip if the parent is a link to the vulnerability page
+      // Skip if the parent is a link to nvd and not replace the link
       if (parent.tagName === 'A' && parent.href.startsWith(VULNERABILITY_BASE_URL)) {
+        // Check if the CVE is in the kev rather than just skipping it previously. v1.3.2 - synfinner
+        const cveText = node.textContent.trim();
+        if (CVE_REGEX.test(cveText)) {
+          enqueueCVECheck(cveText, [parent]);
+          
+        }
         return;
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KEVin CVE Highlighter",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Highlights CVE IDs on web pages, links them to a vulnerability details page, and indicates if they are in the CISA KEV Catalog.",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
It was identified that if a link was already linking to NVD, it would completely skip the check to see if it's in the CISA KEV. This has been fixed by ensuring that the CVE is valid in regex and still sending it to the enqueueCVECheck() function. Bump to version 1.3.2 to reflect these changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CVE identification by processing text within links.

- **Chores**
	- Updated version number of the "KEVin CVE Highlighter" extension from 1.3.1 to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->